### PR TITLE
Fixed recursive paths

### DIFF
--- a/FtpAdapter.php
+++ b/FtpAdapter.php
@@ -370,7 +370,7 @@ class FtpAdapter implements FilesystemAdapter
             }
 
             if (preg_match('#^.*:$#', $item)) {
-                $base = preg_replace('~^\./*|:$~', '', $item);
+                $base = $this->prefixer->stripPrefix(preg_replace('~^\./*|:$~', '', $item));
                 continue;
             }
 


### PR DESCRIPTION
Without this strip function you get the path prefix in sub objects if `$recurseManually` is `false`