### PR TITLE
update isConnected to check for first 3 characters in string for connection response code

### DIFF
--- a/NoopCommandConnectivityChecker.php
+++ b/NoopCommandConnectivityChecker.php
@@ -18,7 +18,7 @@ class NoopCommandConnectivityChecker implements ConnectivityChecker
         }
         // @codeCoverageIgnoreEnd
 
-        $responseCode = $response ? (int) preg_replace('/\D/', '', implode('', $response)) : false;
+        $responseCode = $response ? (int) substr($response[0], 0, 3) : false;
 
         return $responseCode === 200;
     }


### PR DESCRIPTION
When connecting to a Pure-FTP FTP server I am getting back a response like this `200 dc.w $4E71` and in the isConnected method of NoopCommandConnectivityChecker class it is using regular expressions to pull back all digits from the response and therefore it is always returning false since the digits in the response would be 200471. I believe the first 3 characters of the response will always be to response code and therefore I believe it should be checking for this response versus the regular express concept.