### PR TITLE
Fix breaking on folders that contain ":"

### DIFF
--- a/FtpAdapter.php
+++ b/FtpAdapter.php
@@ -380,11 +380,6 @@ class FtpAdapter implements FilesystemAdapter
                 continue;
             }
 
-            if (preg_match('#^.*:$#', $item)) {
-                $base = preg_replace('~^\./*|:$~', '', $item);
-                continue;
-            }
-
             yield $this->normalizeObject($item, $base);
         }
     }


### PR DESCRIPTION
`FtpAdapter` incorrectly handles folders with `:` in the name, even though the FTP protocol can handle it fine.

Example if `ftpRawlist()` returns `drwxr-xr-x   3 1560     1562         4096 Jan 13 10:41 foobar:` 